### PR TITLE
modified SystemUtil to convert str at first then boolean

### DIFF
--- a/tests/test_SystemUtil.py
+++ b/tests/test_SystemUtil.py
@@ -134,6 +134,11 @@ class TestSystemUtil(XrossTestBase):
         self.assertFalse(self.cfg.env.is_real())
         self.assertNotEqual(SystemEnv.UNKNOWN, self.cfg.env)
 
+    def test_get_env_written_nowhere(self):
+        self.assertIsNone(self.cfg.get_env("WRITTEN_NOWHERE"))
+        self.assertFalse(self.cfg.get_env("WRITTEN_NOWHERE", default=False, type=bool))
+        self.assertFalse(self.cfg.get_env("WRITTEN_NOWHERE", default="False", type=bool))
+
 
 if __name__ == '__main__':
     TestSystemUtil.do_test()

--- a/xross_common/SystemUtil.py
+++ b/xross_common/SystemUtil.py
@@ -138,7 +138,7 @@ class SystemUtil(metaclass=Singleton):
             if val is None:
                 val = False
             else:
-                val = ast.literal_eval(val)
+                val = ast.literal_eval(str(val))
         return val
 
     @staticmethod


### PR DESCRIPTION
booleanのデフォルト値に関して，一旦強制的にstrに変換しないと，
```
ValueError: malformed node or string: False
```
がでる