### PR TITLE
modified SystemLogger to remove MultiProcessingHandler because the system run in single process inside each container

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     license=license,
     install_requires=[
         'logutils==0.3.5',
-        'multiprocessing_logging==0.2.5',
         'python-dateutil==2.6.0',
         'munch==2.1.1',
         'pypandoc==1.4',

--- a/xross_common/SystemLogger.py
+++ b/xross_common/SystemLogger.py
@@ -8,7 +8,6 @@ import logging
 import logging.handlers
 
 from logutils.testing import TestHandler, Matcher
-from multiprocessing_logging import MultiProcessingHandler
 
 from xross_common.SystemUtil import SystemUtil
 
@@ -96,17 +95,8 @@ class SystemLogger(logging.getLoggerClass()):
         if not self.cfg.env.is_unittest() and self.cfg.get_env("IS_OUTPUT_TO_LOGFILE", default=False, type=bool):
             handlers.append(self.setup_file_handler())
 
-        if self.cfg.env.is_real():
-            for i, orig_handler in enumerate(handlers):
-                handler = MultiProcessingHandler(
-                    'mp-handler-{0}'.format(i), sub_handler=orig_handler
-                )
-                self.logger.addHandler(handler)
-            self.logger.info("Initialized SystemLogger for %s with %s MultiProcessingHandler"
-                             % (self.obj_name, len(handlers)))
-        else:
-            for orig_handler in handlers:
-                self.logger.addHandler(orig_handler)
+        for orig_handler in handlers:
+            self.logger.addHandler(orig_handler)
         self.logger.info("Loaded SystemLogger LOGGER_LEVEL:%s" % logging.getLevelName(self.levelno))
 
     def get_logger(self):


### PR DESCRIPTION
MultiProcessingHandler が原因でdeserialize時にバグってた
```
Traceback (most recent call last):
File "/usr/local/site-packages/multiprocessing_logging.py", line 57, in _receive
record = self.queue.get()
File "/usr/local/lib-python/3/multiprocessing/queues.py", line 113, in get
return ForkingPickler.loads(res)
File "/usr/local/lib-python/3/pickle.py", line 1587, in _loads
encoding=encoding, errors=errors).load()
File "/usr/local/lib-python/3/pickle.py", line 1063, in load
dispatch[key[0]](self)
File "/usr/local/lib-python/3/pickle.py", line 1347, in load_newobj
obj = cls.__new__(cls, *args)
File "/usr/local/site-packages/md_pubsub-0.2-py3.5.egg/laurel/main/datatypes/Ticker.py", line 12, in __new__
instance.load(*args, **kwargs)
File "/usr/local/site-packages/md_pubsub-0.2-py3.5.egg/laurel/main/datatypes/Ticker.py", line 36, in load
raise ValueError("Insufficient argument: %s" % str(args))
ValueError: Insufficient argument: ()
```

 - [x] Dockerhub でイメージが作られることを確認
https://cloud.docker.com/repository/docker/jimako1989/alunir-build/timeline