### PR TITLE
modified SystemContext get_int to set 0 by get_int unless any value is not set

### DIFF
--- a/tests/test_SystemContext.py
+++ b/tests/test_SystemContext.py
@@ -81,7 +81,20 @@ class TestSystemContext(XrossTestBase):
             self.assertEqual("'SystemContext' object has no attribute 'xxx'", str(ex))
 
     def test_get_int_fail_unless_set(self):
-        self.assertEqual(None, self.cxt.get_int(PARAM_KEY))
+        self.assertEqual(0, self.cxt.get_int(PARAM_KEY))
+
+    def test_get_int_fail_not_decimal(self):
+        self.assertEqual(0, self.cxt.get_int(PARAM_KEY))
+        self.cxt.increment(PARAM_KEY)
+        self.assertEqual(1, self.cxt.get_int(PARAM_KEY))
+
+        self.cxt.set({PARAM_KEY: "a"})
+
+        try:
+            self.cxt.get_int(PARAM_KEY)
+            self.fail()
+        except Exception as e:
+            self.assertEqual("Value:a(Key:hoge) is not decimal", str(e))
 
     def test_increment(self):
         # setup

--- a/xross_common/SystemContext.py
+++ b/xross_common/SystemContext.py
@@ -42,9 +42,9 @@ class SystemContext:
             delattr(self, conv(k))
         self.context.clear()
 
-    def get_int(self, key: str, default: int = None) -> int:
+    def get_int(self, key: str, default: int = 0) -> int:
         if not str(self.get(key, 0)).isdecimal():
-            raise TypeError("%s is not decimal" % key)
+            raise TypeError("Value:%s(Key:%s) is not decimal" % (self.get(key), key))
         return self.get(key, default)
 
     def increment(self, key: str, delta: int = 1) -> int:


### PR DESCRIPTION
get_int でキーがセットされていない場合はNoneではなく0を返すようにした．